### PR TITLE
Fix offset handling and resource rotation

### DIFF
--- a/handler/v20/response.go
+++ b/handler/v20/response.go
@@ -80,6 +80,7 @@ type EchoedSRRequest struct {
 type FCSSearchRetrieve struct {
 	QueryType       QueryType
 	Results         []FCSSearchRow
+	NumberOfRecords int
 	EchoedSRRequest EchoedSRRequest
 }
 

--- a/handler/v20/searchrt.go
+++ b/handler/v20/searchrt.go
@@ -250,13 +250,13 @@ func (a *FCSSubHandlerV20) searchRetrieve(ctx *gin.Context, fcsResponse *FCSResp
 
 	queryType := getTypedArg[QueryType](ctx, "queryType", DefaultQueryType)
 	fcsResponse.SearchRetrieve.QueryType = queryType
-	ranges := query.CalculatePartialRanges(corpora, startRecord, maximumRecords)
+	ranges := query.CalculatePartialRanges(corpora, startRecord-1, maximumRecords)
 
 	// make searches
 	waits := make([]<-chan *rdb.WorkerResult, len(corpora))
-	for i, corpusName := range corpora {
+	for i, rng := range ranges {
 
-		ast, fcsErr := a.translateQuery(corpusName, fcsQuery, queryType)
+		ast, fcsErr := a.translateQuery(rng.Rsc, fcsQuery, queryType)
 		if fcsErr != nil {
 			fcsResponse.General.AddError(*fcsErr)
 			return general.ConformantUnprocessableEntity
@@ -272,10 +272,10 @@ func (a *FCSSubHandlerV20) searchRetrieve(ctx *gin.Context, fcsResponse *FCSResp
 			return general.ConformantUnprocessableEntity
 		}
 		args, err := sonic.Marshal(rdb.ConcExampleArgs{
-			CorpusPath: a.corporaConf.GetRegistryPath(corpusName),
+			CorpusPath: a.corporaConf.GetRegistryPath(rng.Rsc),
 			Query:      query,
 			Attrs:      retrieveAttrs,
-			StartLine:  ranges[corpusName].From - 1,
+			StartLine:  rng.From,
 			MaxItems:   maximumRecords,
 		})
 		if err != nil {
@@ -302,8 +302,8 @@ func (a *FCSSubHandlerV20) searchRetrieve(ctx *gin.Context, fcsResponse *FCSResp
 	}
 
 	// using fromResource, we will cycle through available resources' results and their lines
-	fromResource := result.NewRoundRobinLineSel(corpora...)
-
+	fromResource := result.NewRoundRobinLineSel(maximumRecords, corpora...)
+	var totalConcSize int
 	for i, wait := range waits {
 		rawResult := <-wait
 		result, err := rdb.DeserializeConcExampleResult(rawResult)
@@ -329,7 +329,9 @@ func (a *FCSSubHandlerV20) searchRetrieve(ctx *gin.Context, fcsResponse *FCSResp
 			}
 		}
 		fromResource.SetRscLines(corpora[i], result)
+		totalConcSize += result.ConcSize
 	}
+	fcsResponse.SearchRetrieve.NumberOfRecords = totalConcSize
 	if fromResource.AllHasOutOfRangeError() {
 		fcsResponse.General.AddError(general.FCSError{
 			Code:    general.DCFirstRecordPosOutOfRange,

--- a/handler/v20/templates/fcs-2.0.xml
+++ b/handler/v20/templates/fcs-2.0.xml
@@ -24,7 +24,7 @@
 {{ end }}{{ if eq .Operation "searchRetrieve" }}
 <sruResponse:searchRetrieveResponse xmlns:sruResponse="http://docs.oasis-open.org/ns/search-ws/sruResponse">
   <sruResponse:version>2.0</sruResponse:version>
-  <sruResponse:numberOfRecords>{{ .SearchRetrieve.Results | len }}</sruResponse:numberOfRecords>
+  <sruResponse:numberOfRecords>{{ .SearchRetrieve.NumberOfRecords }}</sruResponse:numberOfRecords>
   {{ if not .General.Fatal }}
     {{ template "searchret.xml" . }}
   {{ end }}

--- a/query/rngcalc.go
+++ b/query/rngcalc.go
@@ -18,9 +18,20 @@
 
 package query
 
-type lineRange struct {
+type LineRange struct {
+	Rsc  string
 	From int
 	To   int
+}
+
+type LineRangeList []LineRange
+
+func (lrlist LineRangeList) Resources() []string {
+	ans := make([]string, len(lrlist))
+	for i, v := range lrlist {
+		ans[i] = v.Rsc
+	}
+	return ans
 }
 
 // CalculatePartialRanges calculates ranges for individual resources (corpora)
@@ -28,25 +39,31 @@ type lineRange struct {
 //  1. we need global offset and limit
 //  2. we create result by round robin selection from individual records.
 //
-// So e.g. for two corpora and offset 100, we set offset 50 for each corpus.
+// Please note that the offset is zero-based! Also, the order of resulting
+// ranges may differ from the `rscList` so the iteration always starts from
+// the correct resource. The order is changed only by rotating the resource list.
+//
+// E.g. for two corpora and offset 100, we set offset 50 for each corpus.
 // But because we don't know whether each of the corpora will be able to provide
 // enough records, we have to set the global limit for each individual resource so
 // in case all but one corpora results are empty, we can still provide the required
 // number of items.
-func CalculatePartialRanges(rscList []string, offset, limit int) map[string]lineRange {
+func CalculatePartialRanges(rscList []string, offset, limit int) LineRangeList {
 
 	numRsc := len(rscList)
 	commonStart := offset / numRsc
 	remaind := offset % numRsc
-	ans := make(map[string]lineRange)
+	ans := make([]LineRange, 0, len(rscList))
 	for i := 0; i < len(rscList); i++ {
-		ans[rscList[i]] = lineRange{commonStart, commonStart + limit}
+		ans = append(ans, LineRange{Rsc: rscList[i], From: commonStart, To: commonStart + limit})
 	}
-	for i := 0; i < int(remaind); i++ {
-		v := ans[rscList[i]]
-		v.From++
-		v.To++
-		ans[rscList[i]] = v
+	for i := 0; i < remaind; i++ {
+		ans[i].From++
+		ans[i].To++
 	}
-	return ans
+	ans2 := make([]LineRange, 0, len(rscList))
+	for i := 0; i < numRsc; i++ {
+		ans2 = append(ans2, ans[(i+remaind)%numRsc])
+	}
+	return ans2
 }

--- a/query/rngcalc_test.go
+++ b/query/rngcalc_test.go
@@ -26,16 +26,19 @@ import (
 
 func TestThreeResourcesOfDiffSizes(t *testing.T) {
 	ans := CalculatePartialRanges([]string{"c1", "c2", "c3"}, 38, 10)
-	assert.Equal(t, 13, ans["c1"].From)
-	assert.Equal(t, 23, ans["c1"].To)
-	assert.Equal(t, 13, ans["c2"].From)
-	assert.Equal(t, 23, ans["c2"].To)
-	assert.Equal(t, 12, ans["c3"].From)
-	assert.Equal(t, 22, ans["c3"].To)
+	assert.Equal(t, 12, ans[0].From)
+	assert.Equal(t, 22, ans[0].To)
+	assert.Equal(t, "c3", ans[0].Rsc)
+	assert.Equal(t, 13, ans[1].From)
+	assert.Equal(t, 23, ans[1].To)
+	assert.Equal(t, "c1", ans[1].Rsc)
+	assert.Equal(t, 13, ans[2].From)
+	assert.Equal(t, 23, ans[2].To)
+	assert.Equal(t, "c2", ans[2].Rsc)
 }
 
 func TestSingleResource(t *testing.T) {
 	ans := CalculatePartialRanges([]string{"c1"}, 38, 10)
-	assert.Equal(t, 38, ans["c1"].From)
-	assert.Equal(t, 48, ans["c1"].To)
+	assert.Equal(t, 38, ans[0].From)
+	assert.Equal(t, 48, ans[0].To)
 }

--- a/result/rscrr_test.go
+++ b/result/rscrr_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func createResource() *RoundRobinLineSel {
-	r := NewRoundRobinLineSel("corp1", "corp2", "corp3")
+	r := NewRoundRobinLineSel(9, "corp1", "corp2", "corp3")
 	r.SetRscLines("corp1", ConcExample{Lines: []conc.ConcordanceLine{
 		{Text: conc.TokenSlice{&conc.Token{Word: "foo1"}}},
 		{Text: conc.TokenSlice{&conc.Token{Word: "foo2"}}},
@@ -47,7 +47,7 @@ func createResource() *RoundRobinLineSel {
 }
 
 func createResourceWithSomeEmpty() *RoundRobinLineSel {
-	r := NewRoundRobinLineSel("corp1", "corp2", "corp3")
+	r := NewRoundRobinLineSel(9, "corp1", "corp2", "corp3")
 	r.SetRscLines("corp1", ConcExample{Lines: []conc.ConcordanceLine{}})
 	r.SetRscLines("corp2", ConcExample{Lines: []conc.ConcordanceLine{
 		{Text: conc.TokenSlice{&conc.Token{Word: "bar1"}}},
@@ -62,30 +62,32 @@ func createResourceWithSomeEmpty() *RoundRobinLineSel {
 	return r
 }
 
-func firstWord(line conc.ConcordanceLine) string {
+func firstWord(line *conc.ConcordanceLine) string {
 	return line.Text[0].Word
-}
-
-func TestEmptyWithoutFactory(t *testing.T) {
-	r := new(RoundRobinLineSel)
-	hasNext := r.setNextAvailRsc()
-	assert.False(t, hasNext)
 }
 
 func TestTypicalSetup(t *testing.T) {
 	r := createResource()
 	r.Next()
 	assert.Equal(t, "foo1", firstWord(r.CurrLine()))
-
-}
-
-func TestAllDepletedWorks(t *testing.T) {
-	r := createResource()
-	for i := 0; i < 9; i++ {
-		r.Next()
-	}
 	r.Next()
-	assert.True(t, r.AllDepleted())
+	assert.Equal(t, "bar1", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "baz1", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "foo2", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "bar2", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "baz2", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "foo3", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "bar3", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "baz3", firstWord(r.CurrLine()))
+	assert.False(t, r.Next())
+	assert.Equal(t, 9, r.lineCounter)
 }
 
 // TestWithSomeEmpty reflects problem reported
@@ -94,8 +96,19 @@ func TestWithSomeEmpty(t *testing.T) {
 	r := createResourceWithSomeEmpty()
 	hasNext := r.Next()
 	assert.True(t, hasNext)
-	ft := firstWord(r.items[r.currIdx].Lines.Lines[0])
-	assert.Equal(t, "bar1", ft)
+	assert.Equal(t, "bar1", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "baz1", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "bar2", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "baz2", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "bar3", firstWord(r.CurrLine()))
+	r.Next()
+	assert.Equal(t, "baz3", firstWord(r.CurrLine()))
+	assert.Equal(t, 9, r.lineCounter)
+	assert.False(t, r.Next())
 }
 
 func TestSetRscLinesPanicsIfIterationStarted(t *testing.T) {


### PR DESCRIPTION
Now the rotation works like this:

1. It starts from corpus/resource which has lowest starting line number and has the lowest index in the original list
2. Internal counter stops when it reaches `maximumRecords` and it is increased even if we try using a depleted resource/corpus result. I.e. we do not try to fill the maximumRecords with a single resource if other ones are small.