### PR TITLE
Fix - explain must report server version 2.0 even in v1.2 mode

### DIFF
--- a/handler/v12/templates/explain.xml
+++ b/handler/v12/templates/explain.xml
@@ -1,6 +1,6 @@
 {{ $primaryLang := .PrimaryLanguage -}}
 <zr:explain xmlns:zr="http://explain.z3950.org/dtd/2.0/">
-  <zr:serverInfo protocol="SRU" version="1.2" transport="http">
+  <zr:serverInfo protocol="SRU" version="2.0" transport="http">
     <zr:host>{{ .ServerName }}</zr:host>
     <zr:port>{{ .ServerPort }}</zr:port>
     <zr:database>{{ .Database }}</zr:database>


### PR DESCRIPTION
(please note that this is a different thing than
sru:explainRespose/sru:version)