### PR TITLE
Use `context` wherever possible to allow proper cancellation and

### DIFF
--- a/cmd/service/fcs.go
+++ b/cmd/service/fcs.go
@@ -73,9 +73,8 @@ func init() {
 }
 
 func runApiServer(
+	ctx context.Context,
 	conf *cnf.Conf,
-	syscallChan chan os.Signal,
-	exitEvent chan os.Signal,
 	radapter *rdb.Adapter,
 ) {
 	log.Info().Msg("Starting MQuery-SRU server")
@@ -88,7 +87,6 @@ func runApiServer(
 	if len(conf.TrustedProxies) > 0 {
 		if err := engine.SetTrustedProxies(conf.TrustedProxies); err != nil {
 			log.Error().Err(err).Msg("Failed to set trusted proxies")
-			syscallChan <- syscall.SIGTERM
 			return
 		}
 	}
@@ -125,17 +123,20 @@ func runApiServer(
 		WriteTimeout: time.Duration(conf.ServerWriteTimeoutSecs) * time.Second,
 		ReadTimeout:  time.Duration(conf.ServerReadTimeoutSecs) * time.Second,
 	}
+
+	srvErrChan := make(chan error, 1)
+
 	go func() {
 		log.Info().Msgf("listening at %s:%d", conf.ListenAddress, conf.ListenPort)
-		err := srv.ListenAndServe()
-		if err != nil {
-			log.Error().Err(err).Msg("")
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			srvErrChan <- err
 		}
-		syscallChan <- syscall.SIGTERM
 	}()
 
 	select {
-	case <-exitEvent:
+	case err := <-srvErrChan:
+		log.Error().Err(err).Msg("Server error")
+	case <-ctx.Done():
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		err := srv.Shutdown(ctx)
@@ -145,11 +146,11 @@ func runApiServer(
 	}
 }
 
-func runWorker(conf *cnf.Conf, workerID string, radapter *rdb.Adapter, exitEvent chan os.Signal) {
+func runWorker(ctx context.Context, conf *cnf.Conf, workerID string, radapter *rdb.Adapter) {
 	log.Info().Msg("Starting MQuery-SRU worker")
 	ch := radapter.Subscribe()
 	logger := monitoring.NewWorkerJobLogger(conf.TimezoneLocation())
-	w := worker.NewWorker(workerID, radapter, ch, exitEvent, logger)
+	w := worker.NewWorker(ctx, workerID, radapter, ch, logger)
 	w.Listen()
 }
 
@@ -213,34 +214,25 @@ func main() {
 	}
 	log.Info().Msg("MQuery-SRU initialization...")
 	cnf.ValidateAndDefaults(conf)
-	syscallChan := make(chan os.Signal, 1)
-	signal.Notify(syscallChan, os.Interrupt)
-	signal.Notify(syscallChan, syscall.SIGTERM)
-	exitEvent := make(chan os.Signal)
-	testConnCancel := make(chan bool)
-	go func() {
-		evt := <-syscallChan
-		testConnCancel <- true
-		close(testConnCancel)
-		exitEvent <- evt
-		close(exitEvent)
-	}()
 
-	radapter := rdb.NewAdapter(conf.Redis)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	radapter := rdb.NewAdapter(ctx, conf.Redis)
 
 	switch action {
 	case "server":
-		err := radapter.TestConnection(20*time.Second, testConnCancel)
+		err := radapter.TestConnection(50*time.Second, 10*time.Second)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to connect to Redis")
 		}
-		runApiServer(conf, syscallChan, exitEvent, radapter)
+		runApiServer(ctx, conf, radapter)
 	case "worker":
-		err := radapter.TestConnection(20*time.Second, testConnCancel)
+		err := radapter.TestConnection(50*time.Second, 10*time.Second)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to connect to Redis")
 		}
-		runWorker(conf, getWorkerID(), radapter, exitEvent)
+		runWorker(ctx, conf, getWorkerID(), radapter)
 	default:
 		log.Fatal().Msgf("Unknown action %s", action)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.0
 require (
 	github.com/czcorpus/cnc-gokit v0.11.0
 	github.com/czcorpus/manabuild v0.1.0
-	github.com/czcorpus/mquery-common v0.4.2
+	github.com/czcorpus/mquery-common v0.4.3
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.3.0
 	github.com/mna/pigeon v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/czcorpus/cnc-gokit v0.11.0 h1:0DSWVAMu6TyBLxeBfTRB/yezoFKQPy1zW8yqUJm
 github.com/czcorpus/cnc-gokit v0.11.0/go.mod h1:BZSRrYUFIHXVIiuqnSoZbfXfL2X/gHWG3w35aIVW36U=
 github.com/czcorpus/manabuild v0.1.0 h1:60sgRj4oM+XqbCKtn/HL+6URXzsfQQCy9TyBWY2iaZE=
 github.com/czcorpus/manabuild v0.1.0/go.mod h1:dj2iAsZObs4yJhF6KkQs5oH2AAyZlrmaNwMGV44hLbk=
-github.com/czcorpus/mquery-common v0.4.2 h1:hHeR9ih4XR46erRr7XrcaUCA0BTFdJA8wqj5lc/CEro=
-github.com/czcorpus/mquery-common v0.4.2/go.mod h1:xAWGWB1e4P43bj0obOWq+Ie5NvutM+ZeSTUB7rEb6po=
+github.com/czcorpus/mquery-common v0.4.3 h1:Zv7UqIM3kyyWGosFhgkXSxsJmwh+gsnpFlo4q649v+c=
+github.com/czcorpus/mquery-common v0.4.3/go.mod h1:xAWGWB1e4P43bj0obOWq+Ie5NvutM+ZeSTUB7rEb6po=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/handler/v12/searchrt.go
+++ b/handler/v12/searchrt.go
@@ -312,7 +312,6 @@ func (a *FCSSubHandlerV12) searchRetrieve(ctx *gin.Context, fcsResponse *FCSRequ
 								collections.SliceMap(
 									item.Text.Tokens(),
 									func(token *concordance.Token, i int) string {
-										fmt.Println("TOK: ", token)
 										if token.Strong {
 											return "<hits:Hit>" + token.Word + "</hits:Hit>"
 										}


### PR DESCRIPTION
timeouts and cancellation using "context"